### PR TITLE
Potential fix for code scanning alert no. 88: Template Object Injection

### DIFF
--- a/routes/dataErasure.ts
+++ b/routes/dataErasure.ts
@@ -69,9 +69,11 @@ router.post('/', async (req: Request<Record<string, unknown>, Record<string, unk
       const filePath: string = path.resolve(req.body.layout).toLowerCase()
       const isForbiddenFile: boolean = (filePath.includes('ftp') || filePath.includes('ctf.key') || filePath.includes('encryptionkeys'))
       if (!isForbiddenFile) {
-        res.render('dataErasureResult', {
-          ...req.body
-        }, (error, html) => {
+        const templateData = {
+          email: req.body.email,
+          securityAnswer: req.body.securityAnswer
+        };
+        res.render('dataErasureResult', templateData, (error, html) => {
           if (!html || error) {
             next(new Error(error.message))
           } else {
@@ -84,9 +86,11 @@ router.post('/', async (req: Request<Record<string, unknown>, Record<string, unk
         next(new Error('File access not allowed'))
       }
     } else {
-      res.render('dataErasureResult', {
-        ...req.body
-      })
+      const templateData = {
+        email: req.body.email,
+        securityAnswer: req.body.securityAnswer
+      };
+      res.render('dataErasureResult', templateData)
     }
   } catch (error) {
     next(error)


### PR DESCRIPTION
Potential fix for [https://github.com/ccuserone/juice-shop/security/code-scanning/88](https://github.com/ccuserone/juice-shop/security/code-scanning/88)

To fix the problem, we need to avoid using the entire `req.body` object directly in the template rendering. Instead, we should explicitly construct an object with only the necessary properties required by the template. This ensures that no unintended properties from the user-controlled object are passed to the template engine.

1. Identify the specific properties needed by the `dataErasureResult` template.
2. Construct an object with only those properties from `req.body`.
3. Use the constructed object in the `res.render` method instead of spreading `req.body`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
